### PR TITLE
Simplify structure: Move all Python scripts to scripts/ folder

### DIFF
--- a/.github/workflows/daily_ceos.yml
+++ b/.github/workflows/daily_ceos.yml
@@ -65,12 +65,12 @@ jobs:
           ARTICLES_SLEEP_SEC: "0.35"
           # ARTICLES_DATE: "YYYY-MM-DD"  # optional for backfills
         run: |
-          python news_articles_ceos.py
+          python scripts/news_articles_ceos.py
 
       # Normalize daily counts and write both data_ceos/<date>.csv and daily_counts.csv
       - name: Run daily CEO sentiment (counts)
         run: |
-          python news_sentiment_ceos.py \
+          python scripts/news_sentiment_ceos.py \
             --aliases data/ceo_aliases.csv \
             --articles-dir data_ceos/articles \
             --daily-dir data_ceos \

--- a/.github/workflows/daily_roc.yml
+++ b/.github/workflows/daily_roc.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
   push:
     paths:
-      - 'news_sentiment_roc.py'
+      - 'scripts/news_sentiment_roc.py'
       - 'requirements.txt'
       - 'roc_aliases.csv'
       - 'roc.txt'
@@ -51,7 +51,7 @@ jobs:
         run: mkdir -p data_roc/articles
 
       - name: Run daily ROC sentiment
-        run: python news_sentiment_roc.py
+        run: python scripts/news_sentiment_roc.py
 
       - name: Commit & push changes (if any)
         run: |

--- a/.github/workflows/sync_lists.yml
+++ b/.github/workflows/sync_lists.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'data/roster.csv'
       - 'scripts/sync_brands_from_roster.py'
-      - 'sync_ceo_lists.py'
+      - 'scripts/sync_ceo_lists.py'
   workflow_dispatch: {}
 
 permissions:
@@ -63,7 +63,7 @@ jobs:
           python-version: '3.11'
 
       - name: Generate CEO lists
-        run: python sync_ceo_lists.py
+        run: python scripts/sync_ceo_lists.py
 
       - name: Commit & push if changed (ceo)
         run: |

--- a/scripts/news_articles_ceos.py
+++ b/scripts/news_articles_ceos.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Builds daily CEO articles from Google News RSS and saves:
+  data_ceos/articles/YYYY-MM-DD-articles.csv
+
+Inputs:
+- data/ceo_aliases.csv  (must include: alias, ceo, company — case-insensitive)
+
+Output columns:
+  ceo, company, title, url, source, sentiment  (sentiment ∈ {positive, neutral, negative})
+
+Notes:
+- Uses Google News RSS (no API key). Be respectful; we keep requests tiny.
+- Classifies sentiment on the HEADLINE text using VADER (lightweight, works well on short headlines).
+"""
+
+from __future__ import annotations
+import os, time, html, sys
+from pathlib import Path
+from datetime import datetime, timezone
+from urllib.parse import quote_plus, urlparse
+
+import pandas as pd
+import requests
+import feedparser
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+
+# Updated BASE to go up one directory since file is now in scripts/
+BASE = Path(__file__).parent.parent
+ALIASES_CSV = BASE / "data" / "ceo_aliases.csv"
+OUT_DIR = BASE / "data_ceos" / "articles"
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+USER_AGENT = "Mozilla/5.0 (compatible; CEO-NewsBot/1.0; +https://example.com/bot)"
+RSS_TMPL = "https://news.google.com/rss/search?q={query}&hl=en-US&gl=US&ceid=US:en"
+
+# Tunables (env overrides)
+MAX_PER_ALIAS = int(os.getenv("ARTICLES_MAX_PER_ALIAS", "25"))
+SLEEP_SEC = float(os.getenv("ARTICLES_SLEEP_SEC", "0.35"))   # polite delay between requests
+TARGET_DATE = os.getenv("ARTICLES_DATE", "").strip()         # YYYY-MM-DD or empty for today (UTC)
+
+
+def target_date() -> str:
+    if TARGET_DATE:
+        try:
+            datetime.strptime(TARGET_DATE, "%Y-%m-%d")
+            return TARGET_DATE
+        except ValueError:
+            print(f"WARNING: invalid ARTICLES_DATE={TARGET_DATE!r}; falling back to today.")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def read_aliases(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing aliases file: {path}")
+    df = pd.read_csv(path)
+    cols = {c.lower(): c for c in df.columns}
+
+    def col(name: str) -> str:
+        for k, v in cols.items():
+            if k == name:
+                return v
+        raise KeyError(f"Expected column '{name}' in {path.name}")
+
+    # normalize & keep required columns
+    out = df[[col("alias"), col("ceo"), col("company")]].copy()
+    out.columns = ["alias", "ceo", "company"]
+    out["alias"] = out["alias"].astype(str).str.strip()
+    out["ceo"] = out["ceo"].astype(str).str.strip()
+    out["company"] = out["company"].astype(str).str.strip()
+    out = out[(out["alias"] != "") & (out["ceo"] != "")]
+    if out.empty:
+        raise ValueError("No alias rows after normalization.")
+    return out.drop_duplicates()
+
+
+def fetch_rss(query: str) -> feedparser.FeedParserDict:
+    url = RSS_TMPL.format(query=quote_plus(query))
+    headers = {"User-Agent": USER_AGENT}
+    resp = requests.get(url, headers=headers, timeout=20)
+    resp.raise_for_status()
+    # feedparser handles bytes/text
+    return feedparser.parse(resp.content)
+
+
+def label_sentiment(analyzer: SentimentIntensityAnalyzer, text: str) -> str:
+    s = analyzer.polarity_scores(text or "")
+    c = s.get("compound", 0.0)
+    if c >= 0.25:
+        return "positive"
+    if c <= -0.05:
+        return "negative"
+    return "neutral"
+
+
+def extract_source(entry) -> str:
+    # feedparser sometimes puts the publisher in entry.source.title
+    try:
+        src = entry.get("source", {}).get("title", "") or ""
+    except Exception:
+        src = ""
+    if src:
+        return str(src).strip()
+    # fallback: domain from link
+    link = entry.get("link") or entry.get("id") or ""
+    try:
+        host = urlparse(link).hostname or ""
+        return host.replace("www.", "")
+    except Exception:
+        return ""
+
+
+def build_articles_for_alias(alias: str, ceo: str, company: str, analyzer) -> list[dict]:
+    try:
+        feed = fetch_rss(alias)
+    except Exception as e:
+        print(f"ERROR fetching RSS for {alias!r}: {e}")
+        return []
+
+    rows = []
+    for entry in (feed.entries or [])[:MAX_PER_ALIAS]:
+        title = html.unescape(entry.get("title", "")).strip()
+        link = (entry.get("link") or entry.get("id") or "").strip()
+        source = extract_source(entry)
+        if not title:
+            continue
+        sent = label_sentiment(analyzer, title)
+        rows.append({
+            "ceo": ceo,
+            "company": company,
+            "title": title,
+            "url": link,
+            "source": source,
+            "sentiment": sent,
+        })
+    return rows
+
+
+def main() -> int:
+    out_date = target_date()
+    out_path = OUT_DIR / f"{out_date}-articles.csv"
+    print(f"Building articles for {out_date} → {out_path}")
+
+    try:
+        aliases = read_aliases(ALIASES_CSV)
+    except Exception as e:
+        print(f"FATAL: {e}")
+        # Still write an empty file so the UI is predictable
+        pd.DataFrame(columns=["ceo","company","title","url","source","sentiment"]).to_csv(out_path, index=False)
+        return 1
+
+    analyzer = SentimentIntensityAnalyzer()
+    all_rows: list[dict] = []
+
+    for i, row in aliases.iterrows():
+        alias = row["alias"]
+        ceo = row["ceo"]
+        company = row["company"]
+        if not alias:
+            continue
+        print(f"[{i+1}/{len(aliases)}] {alias}")
+        rows = build_articles_for_alias(alias, ceo, company, analyzer)
+        all_rows.extend(rows)
+        time.sleep(SLEEP_SEC)
+
+    # de-duplicate (same ceo/title/url)
+    if all_rows:
+        df = pd.DataFrame(all_rows)
+        df = df.drop_duplicates(subset=["ceo","title","url"]).reset_index(drop=True)
+    else:
+        df = pd.DataFrame(columns=["ceo","company","title","url","source","sentiment"])
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(out_path, index=False)
+    print(f"✔ Wrote {len(df):,} rows → {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/news_sentiment_ceos.py
+++ b/scripts/news_sentiment_ceos.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Daily CEO News Sentiment — counts normalizer (restored legacy outputs). 
+
+WHAT THIS DOES
+--------------
+- Reads aliases (CEO + company + alias).
+- Reads today's headline articles (if present) and aggregates per-CEO counts.
+- Writes BOTH of the legacy artifacts the dashboard expects:
+    1) Per-day file:        data_ceos/YYYY-MM-DD.csv
+    2) Master index file:   data_ceos/daily_counts.csv   (append/replace rows for that date)
+
+BEHAVIOR WHEN THERE ARE NO ARTICLES
+-----------------------------------
+- If `data_ceos/articles/YYYY-MM-DD-articles.csv` is missing or empty,
+  we still create rows (0 positive / 0 neutral / 0 negative) for every CEO
+  in aliases, so the date appears in the dashboard date picker.
+
+OUTPUT COLUMNS (match legacy)
+------------------------------
+date, ceo, company, positive, neutral, negative, total, neg_pct, theme, alias
+
+USAGE (optional flags)
+----------------------
+python news_sentiment_ceos.py \
+  --date 2025-09-18 \
+  --aliases data/ceo_aliases.csv \
+  --articles-dir data_ceos/articles \
+  --daily-dir data_ceos \
+  --out data_ceos/daily_counts.csv
+"""
+
+from __future__ import annotations
+import argparse
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+
+
+# -------- Defaults (can be overridden by CLI flags) -------- #
+DEFAULT_ALIASES = "data/ceo_aliases.csv"
+DEFAULT_ARTICLES_DIR = "data_ceos/articles"
+DEFAULT_DAILY_DIR = "data_ceos"
+DEFAULT_OUT = "data_ceos/daily_counts.csv"
+
+
+# ---------------------- Helpers ---------------------------- #
+def iso_today_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def load_aliases(path: Path) -> pd.DataFrame:
+    """
+    Expected headers (case-insensitive): alias, ceo, company
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Aliases file not found: {path}")
+
+    df = pd.read_csv(path)
+    cols = {c.lower(): c for c in df.columns}
+
+    def col(name: str) -> str:
+        for k, v in cols.items():
+            if k == name:
+                return v
+        raise KeyError(f"Expected '{name}' column in {path}")
+
+    out = df[[col("alias"), col("ceo"), col("company")]].copy()
+    out.columns = ["alias", "ceo", "company"]
+    # normalize strings
+    for c in ["alias", "ceo", "company"]:
+        out[c] = out[c].astype(str).fillna("").str.strip()
+    out = out[(out["alias"] != "") & (out["ceo"] != "")]
+    out = out.drop_duplicates(subset=["ceo"]).reset_index(drop=True)
+    if out.empty:
+        raise ValueError("No alias rows after normalization.")
+    return out
+
+
+def load_articles(articles_dir: Path, date_str: str) -> pd.DataFrame:
+    """
+    Reads data_ceos/articles/YYYY-MM-DD-articles.csv if present.
+    Expected columns (case-insensitive): ceo, company, title, url, source, sentiment
+    Returns empty DataFrame (with expected columns) if file missing/empty.
+    """
+    f = articles_dir / f"{date_str}-articles.csv"
+    cols = ["ceo", "company", "title", "url", "source", "sentiment"]
+    if not f.exists():
+        return pd.DataFrame(columns=cols)
+
+    df = pd.read_csv(f)
+    if df.empty:
+        return pd.DataFrame(columns=cols)
+
+    # normalize
+    df = df.rename(columns={c: c.lower() for c in df.columns})
+    for c in cols:
+        if c not in df.columns:
+            df[c] = ""
+    for c in ["ceo", "company", "title", "url", "source", "sentiment"]:
+        df[c] = df[c].astype(str).fillna("").str.strip()
+    df["sentiment"] = df["sentiment"].str.lower()
+    return df[cols]
+
+
+def aggregate_counts(aliases: pd.DataFrame, articles: pd.DataFrame, date_str: str) -> pd.DataFrame:
+    """
+    Returns a DataFrame with legacy columns:
+    date, ceo, company, positive, neutral, negative, total, neg_pct, theme, alias
+    """
+    # Start with aliases so we always have one row per CEO (even with no headlines).
+    base = aliases.copy()
+
+    # Sentiment counts per CEO
+    if not articles.empty:
+        grp = (
+            articles.assign(sentiment=articles["sentiment"].str.lower())
+            .groupby("ceo", dropna=False)["sentiment"]
+            .value_counts()
+            .unstack(fill_value=0)
+            .rename(columns={"positive": "positive", "neutral": "neutral", "negative": "negative"})
+        )
+        # Ensure all three columns exist
+        for col in ["positive", "neutral", "negative"]:
+            if col not in grp.columns:
+                grp[col] = 0
+        grp = grp[["positive", "neutral", "negative"]]
+        base = base.merge(grp, how="left", left_on="ceo", right_index=True)
+    else:
+        base["positive"] = 0
+        base["neutral"] = 0
+        base["negative"] = 0
+
+    base[["positive", "neutral", "negative"]] = base[["positive", "neutral", "negative"]].fillna(0).astype(int)
+    base["total"] = base["positive"] + base["neutral"] + base["negative"]
+    base["neg_pct"] = base.apply(
+        lambda r: round(100.0 * (r["negative"] / r["total"]), 1) if r["total"] > 0 else 0.0, axis=1
+    )
+
+    # Optional: theme column (unknown unless you compute one elsewhere)
+    base["theme"] = ""
+
+    # Reorder + add date
+    out = base[["ceo", "company", "positive", "neutral", "negative", "total", "neg_pct", "theme", "alias"]].copy()
+    out.insert(0, "date", date_str)
+    return out
+
+
+def write_daily_file(daily_dir: Path, date_str: str, daily_rows: pd.DataFrame) -> Path:
+    """
+    Writes data_ceos/YYYY-MM-DD.csv
+    """
+    daily_dir.mkdir(parents=True, exist_ok=True)
+    path = daily_dir / f"{date_str}.csv"
+    daily_rows.to_csv(path, index=False)
+    return path
+
+
+def upsert_master_index(out_path: Path, date_str: str, daily_rows: pd.DataFrame) -> Path:
+    """
+    Replaces rows for date_str in data_ceos/daily_counts.csv with daily_rows;
+    creates the file if missing.
+    """
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if out_path.exists():
+        master = pd.read_csv(out_path)
+        master = master.rename(columns={c: c.lower() for c in master.columns})
+        # Normalize legacy headers if needed
+        expected = ["date", "ceo", "company", "positive", "neutral", "negative", "total", "neg_pct", "theme", "alias"]
+        for col in expected:
+            if col not in master.columns:
+                master[col] = [] if col in ["theme", "alias"] else 0
+        master = master[expected]
+        # Drop existing rows for this date and append fresh ones
+        master = master[master["date"].astype(str) != date_str]
+        master = pd.concat([master, daily_rows], ignore_index=True)
+    else:
+        master = daily_rows.copy()
+
+    # Sort for readability
+    master["date"] = master["date"].astype(str)
+    master = master.sort_values(["date", "ceo"]).reset_index(drop=True)
+    master.to_csv(out_path, index=False)
+    return out_path
+
+
+# ----------------------- CLI / Main ------------------------ #
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Build daily CEO sentiment counts (legacy outputs).")
+    p.add_argument("--date", default=iso_today_utc(), help="Target date (YYYY-MM-DD). Default = today UTC.")
+    p.add_argument("--aliases", default=DEFAULT_ALIASES, help="Path to ceo_aliases.csv")
+    p.add_argument("--articles-dir", default=DEFAULT_ARTICLES_DIR, help="Folder with daily articles CSVs")
+    p.add_argument("--daily-dir", default=DEFAULT_DAILY_DIR, help="Folder to write per-day CSVs")
+    p.add_argument("--out", default=DEFAULT_OUT, help="Path to write/append master index (daily_counts.csv)")
+    return p.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    # Validate date
+    try:
+        datetime.strptime(args.date, "%Y-%m-%d")
+    except ValueError:
+        raise SystemExit(f"Invalid --date '{args.date}'. Expected YYYY-MM-DD.")
+
+    aliases = load_aliases(Path(args.aliases))
+    articles = load_articles(Path(args.articles_dir), args.date)
+    daily_rows = aggregate_counts(aliases, articles, args.date)
+
+    daily_path = write_daily_file(Path(args.daily_dir), args.date, daily_rows)
+    master_path = upsert_master_index(Path(args.out), args.date, daily_rows)
+
+    print(f"✔ Wrote per-day file:  {daily_path}")
+    print(f"✔ Updated master index: {master_path} (rows: {len(pd.read_csv(master_path)):,})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/news_sentiment_roc.py
+++ b/scripts/news_sentiment_roc.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+Simplified Roc Nation News Sentiment with robust themes.
+
+Input (exactly one row per Name):
+  roc_aliases.csv  -> columns: brand,alias   # brand=name, alias=Context
+
+Outputs:
+  data_roc/articles/YYYY-MM-DD.csv
+  data_roc/daily_counts.csv   (includes 'company' and a short 'theme')
+
+Query used per name:
+  "<n>" "<Context>"
+
+Theme logic (negative headlines only):
+  1) bigram/trigram with min_df>=2
+  2) fallback bigram with min_df>=1
+  3) fallback unigrams (top 2–3 words)
+All while removing stopwords + CEO/Company tokens + "ceo".
+"""
+
+import os, csv, time, math, re
+from datetime import datetime, timedelta, date
+from zoneinfo import ZoneInfo
+from urllib.parse import urlencode, urlparse
+
+import feedparser
+import pandas as pd
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+from sklearn.feature_extraction.text import CountVectorizer
+
+# ------------------ Config ------------------
+HL   = "en-US"
+GL   = "US"
+CEID = "US:en"
+
+# Roc inputs
+BRANDS_TXT = "roc.txt"
+ALIASES_CSV = "roc_aliases.csv"
+
+# Output base folder (isolated from other pipelines)
+OUTPUT_BASE = "data_roc"
+ARTICLES_DIR = os.path.join(OUTPUT_BASE, "articles")
+COUNTS_CSV  = os.path.join(OUTPUT_BASE, "daily_counts.csv")
+
+REQUEST_PAUSE_SEC     = 1.0   # polite delay between CEOs
+MAX_ITEMS_PER_QUERY   = 40    # cap per CEO per day
+PURGE_OLDER_THAN_DAYS = 90
+
+MAX_THEME_WORDS = 10
+
+BASE_STOPWORDS = set((
+    "the","a","an","and","or","but","of","for","to","in","on","at","by","with","from","as","about","after","over","under",
+    "this","that","these","those","it","its","their","his","her","they","we","you","our","your","i",
+    "is","are","was","were","be","been","being","has","have","had","do","does","did","will","would","should","can","could","may","might","must",
+    "new","update","updates","report","reports","reported","says","say","said","see","sees","seen","watch","market","stock","shares","share","price","prices",
+    "wins","loss","losses","gain","gains","up","down","amid","amidst","news","today","latest","analyst","analysts","rating","cut","cuts","downgrade","downgrades",
+    "quarter","q1","q2","q3","q4","year","yrs","2024","2025","2026","usd","billion","million","percent","pct","vs","inc","corp","co","ltd","plc"
+))
+
+# Filter out low-signal sources
+BLOCKED_DOMAINS = {
+    "www.prnewswire.com",
+    "www.businesswire.com",
+    "www.globenewswire.com",
+    "investorplace.com",
+    "seekingalpha.com",
+}
+
+# ------------------ Helpers ------------------
+
+def today_str() -> str:
+    return datetime.now(ZoneInfo("US/Eastern")).strftime("%Y-%m-%d")
+
+def load_ceo_company_map(path: str) -> dict:
+    """Read ceo_aliases.csv (brand=CEO, alias=Company) -> {CEO: Company}"""
+    out = {}
+    with open(path, newline="", encoding="utf-8") as f:
+        rdr = csv.DictReader(f)
+        for row in rdr:
+            ceo = (row.get("brand") or "").strip()
+            company = (row.get("alias") or "").strip()
+            if ceo and company:
+                out[ceo] = company
+    return out
+
+def google_news_rss_url(query: str) -> str:
+    base = "https://news.google.com/rss/search"
+    params = {"q": query, "hl": HL, "gl": GL, "ceid": CEID}
+    return base + "?" + urlencode(params)
+
+def domain_of(link: str) -> str:
+    try:
+        return urlparse(link).hostname or ""
+    except Exception:
+        return ""
+
+def fetch_items_for_query(query: str, cap: int) -> list[dict]:
+    url = google_news_rss_url(query)
+    parsed = feedparser.parse(url)
+    out = []
+    for e in parsed.entries[: cap]:
+        link = e.get("link") or ""
+        dom = domain_of(link)
+        if dom in BLOCKED_DOMAINS:
+            continue
+        out.append({
+            "title": (e.get("title") or "").strip(),
+            "link":  link,
+            "published": (e.get("published") or e.get("updated") or "").strip(),
+            "domain": dom,
+        })
+    return out
+
+_analyzer = SentimentIntensityAnalyzer()
+
+def label_sentiment(title: str) -> str:
+    s = _analyzer.polarity_scores(title or "")
+    v = s["compound"]
+    return "positive" if v >= 0.2 else ("negative" if v <= -0.2 else "neutral")
+
+def dedup_by_title_domain(items: list[dict]) -> list[dict]:
+    seen = set()
+    out = []
+    for x in items:
+        key = (x["title"], x["domain"])
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(x)
+    return out
+
+def clean_for_theme(s: str) -> str:
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9\s\-']", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+def tokens_from(s: str) -> set[str]:
+    return set(re.findall(r"[a-zA-Z][a-zA-Z\-']+", (s or "").lower()))
+
+def best_phrase_from(docs: list[str], stopwords: set[str], ngram_range=(2,3), min_df=2) -> str | None:
+    """Return top phrase or None."""
+    vec = CountVectorizer(stop_words=stopwords, ngram_range=ngram_range, min_df=min_df)
+    try:
+        X = vec.fit_transform(docs)
+    except ValueError:
+        return None
+    if X.shape[1] == 0:
+        return None
+    counts = X.sum(axis=0).A1
+    vocab  = vec.get_feature_names_out()
+    top_i  = counts.argmax()
+    phrase = vocab[top_i]
+    words  = phrase.split()
+    if not words:
+        return None
+    if len(words) > MAX_THEME_WORDS:
+        words = words[:MAX_THEME_WORDS]
+    return " ".join(words)
+
+def fallback_keywords(docs: list[str], stopwords: set[str], k: int = 3) -> str | None:
+    """Return top-k unigrams as a phrase, or None."""
+    vec = CountVectorizer(stop_words=stopwords, ngram_range=(1,1), min_df=1)
+    try:
+        X = vec.fit_transform(docs)
+    except ValueError:
+        return None
+    if X.shape[1] == 0:
+        return None
+    counts = X.sum(axis=0).A1
+    vocab  = vec.get_feature_names_out()
+    pairs  = sorted(zip(counts, vocab), reverse=True)
+    words  = [w for _, w in pairs[:k] if w]
+    if not words:
+        return None
+    if len(words) > MAX_THEME_WORDS:
+        words = words[:MAX_THEME_WORDS]
+    return " ".join(words)
+
+def theme_from_negatives(neg_titles: list[str], ceo: str, company: str) -> str:
+    """
+    Build a short theme from negative titles, excluding CEO/company tokens.
+    Tries: (2–3)-grams min_df>=2, then bigrams min_df>=1, then top unigrams.
+    """
+    if not neg_titles:
+        return "None"
+
+    docs = [clean_for_theme(t) for t in neg_titles if t.strip()]
+    if not docs:
+        return "None"
+
+    # dynamic stopwords (base + ceo/company tokens + 'ceo')
+    stop = set(BASE_STOPWORDS)
+    stop |= tokens_from(ceo)
+    stop |= tokens_from(company)
+    stop.add("ceo")
+
+    # 1) strong signal: repeated 2–3 grams
+    p = best_phrase_from(docs, stopwords=stop, ngram_range=(2,3), min_df=2)
+    if p:
+        return p
+
+    # 2) any bigram
+    p = best_phrase_from(docs, stopwords=stop, ngram_range=(2,2), min_df=1)
+    if p:
+        return p
+
+    # 3) top unigrams (2–3 words)
+    p = fallback_keywords(docs, stopwords=stop, k=3)
+    return p if p else "None"
+
+def ensure_dirs():
+    os.makedirs(ARTICLES_DIR, exist_ok=True)
+    os.makedirs(OUTPUT_BASE, exist_ok=True)
+
+def purge_old_files():
+    """Purge using date objects to avoid offset-naive/aware issues."""
+    cutoff_date = date.today() - timedelta(days=PURGE_OLDER_THAN_DAYS)
+
+    # delete old per-day article files
+    for name in os.listdir(ARTICLES_DIR):
+        if not name.endswith(".csv"):
+            continue
+        try:
+            dt = datetime.strptime(name.replace(".csv", ""), "%Y-%m-%d").date()
+        except Exception:
+            continue
+        if dt < cutoff_date:
+            try:
+                os.remove(os.path.join(ARTICLES_DIR, name))
+            except Exception:
+                pass
+
+    # trim old rows in daily_counts.csv
+    if os.path.exists(COUNTS_CSV):
+        df = pd.read_csv(COUNTS_CSV)
+        def keep(row):
+            try:
+                d = datetime.strptime(str(row["date"]), "%Y-%m-%d").date()
+                return d >= cutoff_date
+            except Exception:
+                return True
+        if not df.empty:
+            df2 = df[df.apply(keep, axis=1)]
+            if len(df2) != len(df):
+                df2.to_csv(COUNTS_CSV, index=False)
+
+# ------------------ Main ------------------
+
+def main():
+    print("=== CEO Sentiment (improved themes) : start ===")
+    ensure_dirs()
+    purge_old_files()
+
+    ceo_to_company = load_ceo_company_map(ALIASES_CSV)
+    if not ceo_to_company:
+        raise SystemExit(f"No rows found in {ALIASES_CSV}. Expected header 'brand,alias' with alias=Company.")
+
+    today = today_str()
+    daily_articles_path = os.path.join(ARTICLES_DIR, f"{today}.csv")
+
+    article_rows = []
+    counts_rows  = []
+
+    for idx, (ceo, company) in enumerate(ceo_to_company.items(), start=1):
+        query = f"\"{ceo}\" \"{company}\""
+        items = fetch_items_for_query(query, MAX_ITEMS_PER_QUERY)
+        items = dedup_by_title_domain(items)
+
+        pos = neu = neg = 0
+        neg_titles = []
+
+        for it in items:
+            sent = label_sentiment(it["title"])
+            if sent == "positive": pos += 1
+            elif sent == "negative":
+                neg += 1
+                neg_titles.append(it["title"])
+            else:
+                neu += 1
+
+            article_rows.append({
+                "date": today,
+                "brand": ceo,
+                "company": company,
+                "title": it["title"],
+                "url": it["link"],
+                "domain": it["domain"],
+                "sentiment": sent,
+                "published": it["published"],
+            })
+
+        total = pos + neu + neg
+        theme = theme_from_negatives(neg_titles, ceo=ceo, company=company)
+
+        counts_rows.append({
+            "date": today,
+            "brand": ceo,
+            "company": company,
+            "total": total,
+            "positive": pos,
+            "neutral": neu,
+            "negative": neg,
+            "theme": theme,
+        })
+
+        if idx < len(ceo_to_company):
+            time.sleep(REQUEST_PAUSE_SEC)
+
+    # write per-article
+    with open(daily_articles_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=[
+            "date","brand","company","title","url","domain","sentiment","published"
+        ])
+        w.writeheader()
+        for r in article_rows:
+            w.writerow(r)
+
+    # upsert counts
+    if os.path.exists(COUNTS_CSV):
+        df_old = pd.read_csv(COUNTS_CSV)
+        df_old = df_old[df_old["date"] != today]
+        df_new = pd.DataFrame(counts_rows, columns=[
+            "date","brand","company","total","positive","neutral","negative","theme"
+        ])
+        df_all = pd.concat([df_old, df_new], ignore_index=True)
+        df_all.to_csv(COUNTS_CSV, index=False)
+    else:
+        with open(COUNTS_CSV, "w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=[
+                "date","brand","company","total","positive","neutral","negative","theme"
+            ])
+            w.writeheader()
+            for r in counts_rows:
+                w.writerow(r)
+
+    print(f"Wrote {len(article_rows)} articles -> {daily_articles_path}")
+    print(f"Upserted {len(counts_rows)} rows -> {COUNTS_CSV}")
+    print("=== CEO Sentiment (improved themes) : done ===")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_ceo_lists.py
+++ b/scripts/sync_ceo_lists.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import csv, sys, pathlib
+
+ROSTER = pathlib.Path("data/roster.csv")
+OUT_CEO_COMP = pathlib.Path("ceo_companies.csv")
+OUT_CEO_ALIAS = pathlib.Path("ceo_aliases.csv")
+
+def norm_key(k: str) -> str:
+    return (k or "").strip().lower().replace("\ufeff","")
+
+def main():
+    if not ROSTER.exists():
+        print(f"ERROR: {ROSTER} not found", file=sys.stderr)
+        sys.exit(1)
+
+    with ROSTER.open("r", newline="", encoding="utf-8-sig") as f:
+        rdr = csv.DictReader(f)
+        # Normalize header keys (case-insensitive, BOM-safe)
+        field_map = {k: norm_key(k) for k in rdr.fieldnames or []}
+        rows = []
+        for raw in rdr:
+            row = {field_map[k]: (raw[k] or "").strip() for k in raw}
+            rows.append(row)
+
+    # Accept common header variants
+    def get(row, *names):
+        for n in names:
+            v = row.get(n)
+            if v:
+                return v
+        return ""
+
+    ceo2company = {}
+    for r in rows:
+        ceo = get(r, "ceo", "name", "leader", "executive")
+        company = get(r, "company", "brand", "employer")
+        if not ceo or not company:
+            continue
+        # Keep first mapping if duplicates appear
+        ceo2company.setdefault(ceo, company)
+
+    if not ceo2company:
+        print("WARNING: No CEO/company pairs parsed from roster.csv. Check headers.", file=sys.stderr)
+
+    names = sorted(ceo2company.keys(), key=lambda s: s.lower())
+
+    # 2) ceo_companies.csv
+    with OUT_CEO_COMP.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["CEO","Company"])
+        for ceo in names:
+            w.writerow([ceo, ceo2company[ceo]])
+
+    # 3) ceo_aliases.csv  (one alias per CEO: the company name)
+    with OUT_CEO_ALIAS.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["brand","alias"])
+        for ceo in names:
+            w.writerow([ceo, ceo2company[ceo]])
+
+    print(f"Generated {OUT_CEO_COMP}, {OUT_CEO_ALIAS} from {ROSTER}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR simplifies the repository structure by consolidating all Python scripts into the `scripts/` folder.

## Changes Made

### Files Moved to `scripts/`:
- `news_articles_ceos.py` → `scripts/news_articles_ceos.py`
- `news_sentiment_ceos.py` → `scripts/news_sentiment_ceos.py`
- `news_sentiment_roc.py` → `scripts/news_sentiment_roc.py`
- `sync_ceo_lists.py` → `scripts/sync_ceo_lists.py`

### Code Updates:
- **`scripts/news_articles_ceos.py`**: Updated `BASE` path from `Path(__file__).parent` to `Path(__file__).parent.parent` to correctly reference data directories from the new location

### Workflow Updates:
- **`.github/workflows/daily_ceos.yml`**: Updated to call `scripts/news_articles_ceos.py` and `scripts/news_sentiment_ceos.py`
- **`.github/workflows/daily_roc.yml`**: Updated to call `scripts/news_sentiment_roc.py` and updated trigger paths
- **`.github/workflows/sync_lists.yml`**: Updated to call `scripts/sync_ceo_lists.py` and updated trigger paths

## Benefits
- ✅ Cleaner root directory
- ✅ All Python scripts now organized in one location
- ✅ Maintains existing functionality - all workflows should continue to work as before