### PR TITLE
Fix stock data date handling to use UTC

### DIFF
--- a/brand-dashboard.html
+++ b/brand-dashboard.html
@@ -275,7 +275,11 @@ const DASH_PATTERN = [8, 6];
 /********************** Stock Data **********************/
 async function loadStockData() {
   try {
-    const today = new Date().toISOString().split('T')[0];
+    // Get today's date in UTC (matching the workflow's perspective)
+    const now = new Date();
+    const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const today = todayUTC.toISOString().split('T')[0];
+    
     let stockData = {};
     
     try {
@@ -283,7 +287,11 @@ async function loadStockData() {
       const text = await response.text();
       stockData = parseStockCSV(text);
     } catch {
-      const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+      // Try yesterday in UTC
+      const yesterdayUTC = new Date(todayUTC);
+      yesterdayUTC.setUTCDate(yesterdayUTC.getUTCDate() - 1);
+      const yesterday = yesterdayUTC.toISOString().split('T')[0];
+      
       const response = await fetch(`data/stock_prices/${yesterday}-stock-data.csv`, {cache:'no-store'});
       const text = await response.text();
       stockData = parseStockCSV(text);

--- a/ceo-dashboard.html
+++ b/ceo-dashboard.html
@@ -380,7 +380,11 @@ const canonName = s => String(s || '')
 /********************** Stock Data **********************/
 async function loadStockData() {
   try {
-    const today = new Date().toISOString().split('T')[0];
+    // Get today's date in UTC (matching the workflow's perspective)
+    const now = new Date();
+    const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const today = todayUTC.toISOString().split('T')[0];
+    
     let stockData = {};
     
     try {
@@ -388,7 +392,11 @@ async function loadStockData() {
       const text = await response.text();
       stockData = parseStockCSV(text);
     } catch {
-      const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+      // Try yesterday in UTC
+      const yesterdayUTC = new Date(todayUTC);
+      yesterdayUTC.setUTCDate(yesterdayUTC.getUTCDate() - 1);
+      const yesterday = yesterdayUTC.toISOString().split('T')[0];
+      
       const response = await fetch(`data/stock_prices/${yesterday}-stock-data.csv`, {cache:'no-store'});
       const text = await response.text();
       stockData = parseStockCSV(text);

--- a/sectors.html
+++ b/sectors.html
@@ -200,7 +200,11 @@ const canonBrand = s => String(s || '').toLowerCase().replace(/\s+/g,' ').trim()
 /********************** Stock Data **********************/
 async function loadStockData() {
   try {
-    const today = new Date().toISOString().split('T')[0];
+    // Get today's date in UTC (matching the workflow's perspective)
+    const now = new Date();
+    const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const today = todayUTC.toISOString().split('T')[0];
+    
     let stockData = {};
     
     try {
@@ -208,7 +212,11 @@ async function loadStockData() {
       const text = await response.text();
       stockData = parseStockCSV(text);
     } catch {
-      const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+      // Try yesterday in UTC
+      const yesterdayUTC = new Date(todayUTC);
+      yesterdayUTC.setUTCDate(yesterdayUTC.getUTCDate() - 1);
+      const yesterday = yesterdayUTC.toISOString().split('T')[0];
+      
       const response = await fetch(`data/stock_prices/${yesterday}-stock-data.csv`, {cache:'no-store'});
       const text = await response.text();
       stockData = parseStockCSV(text);


### PR DESCRIPTION
Updates stock data loading logic in brand-dashboard.html, ceo-dashboard.html, and sectors.html to use UTC dates for 'today' and 'yesterday'. This ensures consistency with the workflow's perspective and prevents issues caused by local timezone differences.