### PR TITLE
feat: support pipe-separated controlled URLs in roster

### DIFF
--- a/scripts/process_serps_brands.py
+++ b/scripts/process_serps_brands.py
@@ -8,6 +8,7 @@ Process daily BRAND SERP data:
     (1) Always-controlled platforms (and their subdomains):
         facebook.com, instagram.com, twitter.com, x.com, linkedin.com, play.google.com, apps.apple.com
     (2) Any domain (or its subdomains) present in rosters/main-roster.csv (Website column)
+        Multiple URLs can be separated by pipe (|) character
     (3) Domain contains the normalized brand token
 
 - If CONTROLLED and FORCE_POSITIVE_IF_CONTROLLED = True -> sentiment is forced to "positive"
@@ -113,6 +114,10 @@ def _norm_domain_for_name_match(host: str) -> str:
 # Roster loading
 # -----------------------
 def load_roster_domains(path: str = MAIN_ROSTER_PATH) -> Set[str]:
+    """
+    Load controlled domains from roster.
+    Supports pipe-separated URLs in a single cell: 'domain1.com|domain2.com|domain3.com'
+    """
     domains: Set[str] = set()
 
     if not os.path.exists(path):
@@ -136,12 +141,19 @@ def load_roster_domains(path: str = MAIN_ROSTER_PATH) -> Set[str]:
         for val in df[website_col].dropna().astype(str):
             val = val.strip()
             if val and val != "nan":
-                if not val.startswith(("http://", "https://")):
-                    val = f"http://{val}"
-                host = _hostname(val)
-                if host and "." in host:
-                    domains.add(host)
-                    
+                # Split on pipe character to support multiple URLs per company
+                urls = val.split("|")
+                
+                for url in urls:
+                    url = url.strip()
+                    if not url:
+                        continue
+                    if not url.startswith(("http://", "https://")):
+                        url = f"http://{url}"
+                    host = _hostname(url)
+                    if host and "." in host:
+                        domains.add(host)
+                        
     except Exception as e:
         print(f"[WARN] failed reading roster at {path}: {e}")
 

--- a/scripts/process_serps_ceos.py
+++ b/scripts/process_serps_ceos.py
@@ -125,6 +125,10 @@ def fetch_csv_text(url: str, timeout=30):
     return r.text
 
 def load_roster_data():
+    """
+    Load roster data with support for pipe-separated URLs.
+    Example: 'apple.com|support.apple.com|developer.apple.com'
+    """
     if not MAIN_ROSTER_PATH.exists():
         raise FileNotFoundError(f"Main roster not found: {MAIN_ROSTER_PATH}")
 
@@ -170,16 +174,23 @@ def load_roster_data():
         for val in df[website_col].dropna().astype(str):
             val = val.strip()
             if val and val != "nan":
-                try:
-                    if not val.startswith(("http://", "https://")):
-                        val = f"https://{val}"
-                    parsed = urlparse(val)
-                    host = (parsed.netloc or parsed.path or "").lower().strip()
-                    host = host.replace("www.", "")
-                    if host and "." in host:
-                        controlled_domains.add(host)
-                except Exception:
-                    pass
+                # Split on pipe character to support multiple URLs per company
+                urls = val.split("|")
+                
+                for url in urls:
+                    url = url.strip()
+                    if not url:
+                        continue
+                    try:
+                        if not url.startswith(("http://", "https://")):
+                            url = f"https://{url}"
+                        parsed = urlparse(url)
+                        host = (parsed.netloc or parsed.path or "").lower().strip()
+                        host = host.replace("www.", "")
+                        if host and "." in host:
+                            controlled_domains.add(host)
+                    except Exception:
+                        pass
 
     return alias_map, ceo_to_company, controlled_domains
 


### PR DESCRIPTION
## 🎯 Feature: Support Pipe-Separated Controlled URLs in Roster

### Problem
Previously, if you wanted to specify multiple controlled domains for a company in `main-roster.csv`, you could only enter a single URL in the Website column. This limitation meant that companies with multiple official web properties (like support sites, developer docs, regional pages) couldn't be fully represented in the system.

### Solution
This PR enables the use of pipe-separated URLs (`|`) within a single roster cell, allowing multiple domains per company to be recognized as "controlled" in SERP results.

### Changes Made
1. **process_serps_brands.py**
   - Updated `load_roster_domains()` function to split on pipe character
   - Each URL is parsed individually and added to controlled domains set
   - Fully backward compatible with existing single URLs

2. **process_serps_ceos.py**
   - Applied same enhancement for consistency across both brand and CEO tracking
   - CEO roster can now use pipe-separated URLs in the Website column

### Usage Example
In `rosters/main-roster.csv`, you can now write:
```
company,website
Apple,apple.com|support.apple.com|developer.apple.com
Google,google.com|blog.google.com|play.google.com
```

All three domains for each company will now be correctly tagged as "controlled" when they appear in SERP results.

### Technical Details
- Parsing happens with `val.split("|")` after stripping whitespace
- Each URL is individually normalized and validated
- Protocol validation (http/https) applies to each URL separately
- Subdomain matching works correctly for all pipe-separated URLs
- Empty segments are safely ignored

### Testing Recommendations
1. Update your roster with pipe-separated URLs for a test company
2. Run the SERP processing scripts
3. Verify in the SERP modal that all domains now show "controlled" badge
4. Confirm backward compatibility by testing with single URLs (no pipes)

### Breaking Changes
None - this is fully backward compatible. Existing single-URL entries will continue to work exactly as before.

---
**Note for learning:** This change demonstrates a common pattern in data processing - taking user input in a simplified format (pipe-separated strings) and parsing it into a data structure (set of domains) that your application can efficiently query. The key insight is doing the parsing once at load time rather than repeatedly during SERP classification, which keeps the system performant.